### PR TITLE
Added a linelist for prep clients eligible for HTS test, bug fix for prep followup adherence outcome

### DIFF
--- a/api/src/main/java/org/openmrs/module/prep/reporting/builder/PrEPRegisterReportBuilder.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/builder/PrEPRegisterReportBuilder.java
@@ -134,7 +134,7 @@ public class PrEPRegisterReportBuilder extends AbstractHybridReportBuilder {
 		dsd.addColumn("Sex", new GenderDataDefinition(), "");
 		dsd.addColumn("DOB", new BirthdateDataDefinition(), "", new BirthdateConverter(DATE_FORMAT));
 		dsd.addColumn("Age", new AgeDataDefinition(), "");
-		dsd.addColumn("Population Type", new PrEPPopulationTypeDataDefinition(), "");
+		dsd.addColumn("Population Type", new PrEPHTSPopulationTypeDataDefinition(), "");
 		dsd.addColumn("Assessed", new AssessedDataDefinition(), "");
 		dsd.addColumn("Eligible", new EligibleDataDefinition(), "");
 		dsd.addColumn("PrEP Initiation Date", new InitiationDateDataDefinition(), "");

--- a/api/src/main/java/org/openmrs/module/prep/reporting/builder/PrepClientsEligibleForHTSTestReportBuilder.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/builder/PrepClientsEligibleForHTSTestReportBuilder.java
@@ -1,0 +1,116 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.prep.reporting.builder;
+
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.module.kenyacore.report.HybridReportDescriptor;
+import org.openmrs.module.kenyacore.report.ReportDescriptor;
+import org.openmrs.module.kenyacore.report.ReportUtils;
+import org.openmrs.module.kenyacore.report.builder.AbstractHybridReportBuilder;
+import org.openmrs.module.kenyacore.report.builder.Builds;
+import org.openmrs.module.metadatadeploy.MetadataUtils;
+import org.openmrs.module.prep.metadata.PrepMetadata;
+import org.openmrs.module.prep.reporting.cohort.definition.CurrentlyOnPrepCohortDefinition;
+import org.openmrs.module.prep.reporting.cohort.definition.PrepClientsEligibleForHTSTestCohortDefinition;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.PrepPopulatonTypeDataDefinition;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.InitiationDateDataDefinition;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.PrEPVisitDateDataDefinition;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.NextAppointmentDateDataDefinition;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.HivTestDueDateDataDefinition;
+import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
+import org.openmrs.module.reporting.data.DataDefinition;
+import org.openmrs.module.reporting.data.converter.BirthdateConverter;
+import org.openmrs.module.reporting.data.converter.DataConverter;
+import org.openmrs.module.reporting.data.converter.ObjectFormatter;
+import org.openmrs.module.reporting.data.converter.DateConverter;
+import org.openmrs.module.reporting.data.patient.definition.ConvertedPatientDataDefinition;
+import org.openmrs.module.reporting.data.patient.definition.PatientIdentifierDataDefinition;
+import org.openmrs.module.reporting.data.person.definition.BirthdateDataDefinition;
+import org.openmrs.module.reporting.data.person.definition.ConvertedPersonDataDefinition;
+import org.openmrs.module.reporting.data.person.definition.GenderDataDefinition;
+import org.openmrs.module.reporting.data.person.definition.PersonIdDataDefinition;
+import org.openmrs.module.reporting.data.person.definition.PreferredNameDataDefinition;
+import org.openmrs.module.reporting.dataset.definition.DataSetDefinition;
+import org.openmrs.module.reporting.dataset.definition.PatientDataSetDefinition;
+import org.openmrs.module.reporting.evaluation.parameter.Mapped;
+import org.openmrs.module.reporting.evaluation.parameter.Parameter;
+import org.openmrs.module.reporting.report.definition.ReportDefinition;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+@Component
+@Builds({ "kenyaemr.prep.prep.report.PrepClientsEligibleForHtsTestLineList" })
+public class PrepClientsEligibleForHTSTestReportBuilder extends AbstractHybridReportBuilder {
+	
+	public static final String DATE_FORMAT = "dd/MM/yyyy";
+	
+	@Override
+	protected List<Parameter> getParameters(ReportDescriptor reportDescriptor) {
+		return Arrays.asList(new Parameter("startDate", "Start Date", Date.class), new Parameter("endDate", "End Date",
+		        Date.class), new Parameter("dateBasedReporting", "", String.class));
+	}
+	
+	@Override
+	protected void addColumns(HybridReportDescriptor report, PatientDataSetDefinition dsd) {
+	}
+	
+	@Override
+	protected Mapped<CohortDefinition> buildCohort(HybridReportDescriptor descriptor, PatientDataSetDefinition dsd) {
+		return null;
+	}
+	
+	protected Mapped<CohortDefinition> allClientsCohort() {
+		CohortDefinition cd = new PrepClientsEligibleForHTSTestCohortDefinition();
+		cd.addParameter(new Parameter("startDate", "Start Date", Date.class));
+		cd.addParameter(new Parameter("endDate", "End Date", Date.class));
+		cd.setName("PrEP Clients Eligible for HTS Test");
+		return ReportUtils.map(cd, "startDate=${startDate},endDate=${endDate}");
+	}
+	
+	@Override
+	protected List<Mapped<DataSetDefinition>> buildDataSets(ReportDescriptor descriptor, ReportDefinition report) {
+		
+		PatientDataSetDefinition eligibleClients = currentlyOnPrepDataSetDefinition("prepClientsHTSEligible");
+		eligibleClients.addRowFilter(allClientsCohort());
+		DataSetDefinition eligibleClientsDSD = eligibleClients;
+		
+		return Arrays.asList(ReportUtils.map(eligibleClientsDSD, "startDate=${startDate},endDate=${endDate}"));
+	}
+	
+	protected PatientDataSetDefinition currentlyOnPrepDataSetDefinition(String datasetName) {
+		
+		PatientDataSetDefinition dsd = new PatientDataSetDefinition(datasetName);
+		dsd.addParameter(new Parameter("startDate", "Start Date", Date.class));
+		dsd.addParameter(new Parameter("endDate", "End Date", Date.class));
+		String defParam = "startDate=${startDate},endDate=${endDate}";
+		PatientIdentifierType upn = MetadataUtils.existing(PatientIdentifierType.class,
+		    PrepMetadata._PatientIdentifierType.PREP_UNIQUE_NUMBER);
+		DataConverter identifierFormatter = new ObjectFormatter("{identifier}");
+		DataDefinition identifierDef = new ConvertedPatientDataDefinition("identifier", new PatientIdentifierDataDefinition(
+		        upn.getName(), upn), identifierFormatter);
+		
+		DataConverter formatter = new ObjectFormatter("{familyName}, {givenName}");
+		DataDefinition nameDef = new ConvertedPersonDataDefinition("name", new PreferredNameDataDefinition(), formatter);
+		dsd.addColumn("id", new PersonIdDataDefinition(), "");
+		dsd.addColumn("Name", nameDef, "");
+		dsd.addColumn("PrEP No", identifierDef, "");
+		dsd.addColumn("Sex", new GenderDataDefinition(), "", null);
+		dsd.addColumn("DOB", new BirthdateDataDefinition(), "", new BirthdateConverter(DATE_FORMAT));
+		dsd.addColumn("Population type", new PrepPopulatonTypeDataDefinition(), "");
+		dsd.addColumn("Prep Start date", new InitiationDateDataDefinition(), "");
+		dsd.addColumn("Last visit date", new PrEPVisitDateDataDefinition(), "");
+		dsd.addColumn("Date due for HIV test", new HivTestDueDateDataDefinition(), "");
+		dsd.addColumn("Next appointment date", new NextAppointmentDateDataDefinition(), "");
+		return dsd;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/prep/reporting/builder/PrepClientsEligibleForHTSTestReportBuilder.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/builder/PrepClientsEligibleForHTSTestReportBuilder.java
@@ -107,7 +107,7 @@ public class PrepClientsEligibleForHTSTestReportBuilder extends AbstractHybridRe
 		dsd.addColumn("Sex", new GenderDataDefinition(), "", null);
 		dsd.addColumn("DOB", new BirthdateDataDefinition(), "", new BirthdateConverter(DATE_FORMAT));
 		dsd.addColumn("Population type", new PrepPopulatonTypeDataDefinition(), "");
-		dsd.addColumn("Prep Start date", new InitiationDateDataDefinition(), "");
+		dsd.addColumn("PrEP Start date", new InitiationDateDataDefinition(), "");
 		dsd.addColumn("Last visit date", new PrEPVisitDateDataDefinition(), "");
 		dsd.addColumn("Date due for HIV test", new HivTestDueDateDataDefinition(), "");
 		dsd.addColumn("Next appointment date", new NextAppointmentDateDataDefinition(), "");

--- a/api/src/main/java/org/openmrs/module/prep/reporting/cohort/definition/PrepClientsEligibleForHTSTestCohortDefinition.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/cohort/definition/PrepClientsEligibleForHTSTestCohortDefinition.java
@@ -1,0 +1,24 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.prep.reporting.cohort.definition;
+
+import org.openmrs.module.reporting.cohort.definition.BaseCohortDefinition;
+import org.openmrs.module.reporting.common.Localized;
+import org.openmrs.module.reporting.definition.configuration.ConfigurationPropertyCachingStrategy;
+import org.openmrs.module.reporting.evaluation.caching.Caching;
+
+/**
+ * PrEP clients eligible for HTS Test definition
+ */
+@Caching(strategy = ConfigurationPropertyCachingStrategy.class)
+@Localized("reporting.PrepClientsEligibleForHTSTestCohortDefinition")
+public class PrepClientsEligibleForHTSTestCohortDefinition extends BaseCohortDefinition {
+	
+}

--- a/api/src/main/java/org/openmrs/module/prep/reporting/cohort/definition/evaluator/PrepClientsEligibleForHTSTestCohortDefinitionEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/cohort/definition/evaluator/PrepClientsEligibleForHTSTestCohortDefinitionEvaluator.java
@@ -1,0 +1,83 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.prep.reporting.cohort.definition.evaluator;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Cohort;
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.prep.reporting.cohort.definition.CurrentlyOnPrepCohortDefinition;
+import org.openmrs.module.prep.reporting.cohort.definition.PrepClientsEligibleForHTSTestCohortDefinition;
+import org.openmrs.module.reporting.cohort.EvaluatedCohort;
+import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
+import org.openmrs.module.reporting.cohort.definition.evaluator.CohortDefinitionEvaluator;
+import org.openmrs.module.reporting.evaluation.EvaluationContext;
+import org.openmrs.module.reporting.evaluation.EvaluationException;
+import org.openmrs.module.reporting.evaluation.querybuilder.SqlQueryBuilder;
+import org.openmrs.module.reporting.evaluation.service.EvaluationService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Evaluator for PrepClientsEligibleForHTSTestCohortDefinition
+ */
+@Handler(supports = { PrepClientsEligibleForHTSTestCohortDefinition.class })
+public class PrepClientsEligibleForHTSTestCohortDefinitionEvaluator implements CohortDefinitionEvaluator {
+	
+	private final Log log = LogFactory.getLog(this.getClass());
+	
+	@Autowired
+	EvaluationService evaluationService;
+	
+	@Override
+	public EvaluatedCohort evaluate(CohortDefinition cohortDefinition, EvaluationContext context) throws EvaluationException {
+		
+		PrepClientsEligibleForHTSTestCohortDefinition definition = (PrepClientsEligibleForHTSTestCohortDefinition) cohortDefinition;
+		
+		if (definition == null)
+			return null;
+		
+		Cohort newCohort = new Cohort();
+		
+		String qry = "select e.patient_id\n"
+		        + "from (\n"
+		        + "       select enr.patient_id,\n"
+		        + "              d.patient_id as disc_patient ,\n"
+		        + "              max(d.visit_date) as date_discontinued,\n"
+		        + "              max(enr.visit_date) as enrollment_date,\n"
+		        + "              max(t.visit_date) as latest_test_date,\n"
+		        + "              mid(max(concat(t.visit_date,t.final_test_result)),11) as hiv_status\n"
+		        + "       from kenyaemr_etl.etl_prep_enrolment enr\n"
+		        + "         join kenyaemr_etl.etl_patient_demographics p on p.patient_id=enr.patient_id and p.voided=0 and p.dead=0\n"
+		        + "         join kenyaemr_etl.etl_hts_test t on t.patient_id=enr.patient_id\n"
+		        + "         left join  (select patient_id,visit_date from kenyaemr_etl.etl_prep_discontinuation) d on d.patient_id = enr.patient_id\n"
+		        + "         group by patient_id\n"
+		        + "         having (hiv_status = \"Negative\")\n"
+		        + "                  and ((timestampdiff(MONTH,date(latest_test_date),date(:endDate)) > 3)\n"
+		        + "                       or ((enrollment_date between date_sub(:endDate, interval 1 MONTH) and date(:endDate))\n"
+		        + "                              and timestampdiff(MONTH,date(latest_test_date),date(:endDate)) > 1))\n"
+		        + "                  and\n"
+		        + "                   (disc_patient is null or date(enrollment_date) >= date(date_discontinued) ) )e;\n";
+		
+		SqlQueryBuilder builder = new SqlQueryBuilder();
+		builder.append(qry);
+		Date startDate = (Date) context.getParameterValue("startDate");
+		Date endDate = (Date) context.getParameterValue("endDate");
+		builder.addParameter("startDate", startDate);
+		builder.addParameter("endDate", endDate);
+		
+		List<Integer> ptIds = evaluationService.evaluateToList(builder, Integer.class, context);
+		newCohort.setMemberIds(new HashSet<Integer>(ptIds));
+		return new EvaluatedCohort(newCohort, definition, context);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/evaluator/prep/HivTestDueDateDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/evaluator/prep/HivTestDueDateDataEvaluator.java
@@ -1,0 +1,55 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.prep.reporting.data.converter.definition.evaluator.prep;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.HivTestDueDateDataDefinition;
+import org.openmrs.module.reporting.data.person.EvaluatedPersonData;
+import org.openmrs.module.reporting.data.person.definition.PersonDataDefinition;
+import org.openmrs.module.reporting.data.person.evaluator.PersonDataEvaluator;
+import org.openmrs.module.reporting.evaluation.EvaluationContext;
+import org.openmrs.module.reporting.evaluation.EvaluationException;
+import org.openmrs.module.reporting.evaluation.querybuilder.SqlQueryBuilder;
+import org.openmrs.module.reporting.evaluation.service.EvaluationService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+import java.util.Date;
+
+/**
+ * Evaluates HivTestDueDateDataDefinition
+ */
+@Handler(supports = HivTestDueDateDataDefinition.class, order = 50)
+public class HivTestDueDateDataEvaluator implements PersonDataEvaluator {
+	
+	@Autowired
+	private EvaluationService evaluationService;
+	
+	public EvaluatedPersonData evaluate(PersonDataDefinition definition, EvaluationContext context)
+	        throws EvaluationException {
+		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
+		
+		String qry = "select enr.patient_id,\n"
+		        + "  if(enr.visit_date between date_sub(:endDate, interval 1 MONTH) and date(:endDate),date_add(max(t.visit_date), INTERVAL 1 MONTH),date_add(max(t.visit_date), INTERVAL 3 MONTH)) as due_test_date\n"
+		        + "from  kenyaemr_etl.etl_prep_enrolment enr\n"
+		        + "  join (select patient_id, visit_date from kenyaemr_etl.etl_hts_test) t on t.patient_id = enr.patient_id\n"
+		        + "group by t.patient_id;";
+		
+		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
+		Date startDate = (Date) context.getParameterValue("startDate");
+		Date endDate = (Date) context.getParameterValue("endDate");
+		queryBuilder.addParameter("endDate", endDate);
+		queryBuilder.addParameter("startDate", startDate);
+		queryBuilder.append(qry);
+		Map<Integer, Object> data = evaluationService.evaluateToMap(queryBuilder, Integer.class, Object.class, context);
+		c.setData(data);
+		return c;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/evaluator/prep/PrEPHTSPopulationTypeDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/evaluator/prep/PrEPHTSPopulationTypeDataEvaluator.java
@@ -1,0 +1,47 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.prep.reporting.data.converter.definition.evaluator.prep;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.PrEPHTSPopulationTypeDataDefinition;
+import org.openmrs.module.reporting.data.person.EvaluatedPersonData;
+import org.openmrs.module.reporting.data.person.definition.PersonDataDefinition;
+import org.openmrs.module.reporting.data.person.evaluator.PersonDataEvaluator;
+import org.openmrs.module.reporting.evaluation.EvaluationContext;
+import org.openmrs.module.reporting.evaluation.EvaluationException;
+import org.openmrs.module.reporting.evaluation.querybuilder.SqlQueryBuilder;
+import org.openmrs.module.reporting.evaluation.service.EvaluationService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+
+/**
+ * Evaluates PrEPHTSPopulationTypeDataDefinition
+ */
+@Handler(supports = PrEPHTSPopulationTypeDataDefinition.class, order = 50)
+public class PrEPHTSPopulationTypeDataEvaluator implements PersonDataEvaluator {
+	
+	@Autowired
+	private EvaluationService evaluationService;
+	
+	public EvaluatedPersonData evaluate(PersonDataDefinition definition, EvaluationContext context)
+	        throws EvaluationException {
+		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
+		
+		String qry = "select e.patient_id,t.population_type from kenyaemr_etl.etl_prep_enrolment e left outer join kenyaemr_etl.etl_hts_test t\n"
+		        + "on e.patient_id = t.patient_id group by e.patient_id;";
+		
+		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
+		queryBuilder.append(qry);
+		Map<Integer, Object> data = evaluationService.evaluateToMap(queryBuilder, Integer.class, Object.class, context);
+		c.setData(data);
+		return c;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/evaluator/prep/PrepPopulationTypeDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/evaluator/prep/PrepPopulationTypeDataEvaluator.java
@@ -10,7 +10,7 @@
 package org.openmrs.module.prep.reporting.data.converter.definition.evaluator.prep;
 
 import org.openmrs.annotation.Handler;
-import org.openmrs.module.prep.reporting.data.converter.definition.prep.PrepPopulatonTypeDataDefinition;
+import org.openmrs.module.prep.reporting.data.converter.definition.prep.PrEPPopulationTypeDataDefinition;
 import org.openmrs.module.reporting.data.person.EvaluatedPersonData;
 import org.openmrs.module.reporting.data.person.definition.PersonDataDefinition;
 import org.openmrs.module.reporting.data.person.evaluator.PersonDataEvaluator;
@@ -23,10 +23,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Map;
 
 /**
- * Evaluates Population type Data Definition
+ * Evaluates PersonDataDefinition
  */
-@Handler(supports = PrepPopulatonTypeDataDefinition.class, order = 50)
-public class PrepPopulationTypeDataEvaluator implements PersonDataEvaluator {
+@Handler(supports = PrEPPopulationTypeDataDefinition.class, order = 50)
+public class PrEPPopulationTypeDataEvaluator implements PersonDataEvaluator {
 	
 	@Autowired
 	private EvaluationService evaluationService;
@@ -35,8 +35,8 @@ public class PrepPopulationTypeDataEvaluator implements PersonDataEvaluator {
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
 		
-		String qry = "SELECT patient_id,mid(max(concat(visit_date,case population_type when 164928 then 'General Population' when 6096 then 'Discondant Couple' when 164929 then 'Key Population' end)),11) as population_type \n"
-		        + "FROM kenyaemr_etl.etl_prep_enrolment group by patient_id;";
+		String qry = "select e.patient_id,t.population_type from kenyaemr_etl.etl_prep_enrolment e left outer join kenyaemr_etl.etl_hts_test t\n"
+		        + "on e.patient_id = t.patient_id group by e.patient_id;";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/prep/HivTestDueDateDataDefinition.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/prep/HivTestDueDateDataDefinition.java
@@ -1,0 +1,49 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.prep.reporting.data.converter.definition.prep;
+
+import org.openmrs.module.reporting.data.BaseDataDefinition;
+import org.openmrs.module.reporting.data.person.definition.PersonDataDefinition;
+import org.openmrs.module.reporting.definition.configuration.ConfigurationPropertyCachingStrategy;
+import org.openmrs.module.reporting.evaluation.caching.Caching;
+
+import java.util.Date;
+
+/**
+ * Hiv Due date Column
+ */
+@Caching(strategy = ConfigurationPropertyCachingStrategy.class)
+public class HivTestDueDateDataDefinition extends BaseDataDefinition implements PersonDataDefinition {
+	
+	public static final long serialVersionUID = 1L;
+	
+	/**
+	 * Default Constructor
+	 */
+	public HivTestDueDateDataDefinition() {
+		super();
+	}
+	
+	/**
+	 * Constructor to hiv due date only
+	 */
+	public HivTestDueDateDataDefinition(String name) {
+		super(name);
+	}
+	
+	//***** INSTANCE METHODS *****
+	
+	/**
+	 * @see org.openmrs.module.reporting.data.DataDefinition#getDataType()
+	 */
+	public Class<?> getDataType() {
+		return Date.class;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/prep/PrEPHTSPopulationTypeDataDefinition.java
+++ b/api/src/main/java/org/openmrs/module/prep/reporting/data/converter/definition/prep/PrEPHTSPopulationTypeDataDefinition.java
@@ -16,24 +16,24 @@ import org.openmrs.module.reporting.definition.configuration.ConfigurationProper
 import org.openmrs.module.reporting.evaluation.caching.Caching;
 
 /**
- * Visit ID Column
+ * Column PrEPHTSPopulationTypeDataDefinition
  */
 @Caching(strategy = ConfigurationPropertyCachingStrategy.class)
-public class PrEPPopulationTypeDataDefinition extends BaseDataDefinition implements PersonDataDefinition {
+public class PrEPHTSPopulationTypeDataDefinition extends BaseDataDefinition implements PersonDataDefinition {
 	
 	public static final long serialVersionUID = 1L;
 	
 	/**
 	 * Default Constructor
 	 */
-	public PrEPPopulationTypeDataDefinition() {
+	public PrEPHTSPopulationTypeDataDefinition() {
 		super();
 	}
 	
 	/**
 	 * Constructor to populate name only
 	 */
-	public PrEPPopulationTypeDataDefinition(String name) {
+	public PrEPHTSPopulationTypeDataDefinition(String name) {
 		super(name);
 	}
 	

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -297,7 +297,7 @@
             </set>
         </property>
     </bean>
-    <!--Prep eligible for HTS-->
+    <!--PrEP eligible for HTS-->
     <bean id="kenyaemr.prep.prep.report.PrepClientsEligibleForHtsTestLineList" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">
         <property name="targetUuid" value="56ff20f5-231b-447f-a58f-681184c3b377" />
         <property name="name" value="PrEP clients eligible for HTS Test" />

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -100,6 +100,7 @@
                 <ref bean="kenyaemr.prep.prep.report.EverEnrolledClientsLinelist" />
                 <ref bean="kenyaemr.prep.prep.report.prepMissedAppointments" />
                 <ref bean="kenyaemr.prep.prep.report.CurrentlyOnPrepLineList" />
+                <ref bean="kenyaemr.prep.prep.report.PrepClientsEligibleForHtsTestLineList" />
             </set>
         </property>
     </bean>
@@ -295,5 +296,15 @@
                 <ref bean="kenyaemr.app.reports" />
             </set>
         </property>
+    </bean>
+    <!--Prep eligible for HTS-->
+    <bean id="kenyaemr.prep.prep.report.PrepClientsEligibleForHtsTestLineList" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">
+        <property name="targetUuid" value="56ff20f5-231b-447f-a58f-681184c3b377" />
+        <property name="name" value="PrEP clients eligible for HTS Test" />
+        <property name="description" value="A comprehensive line list of PrEP clients eligible for HTS Test" />
+        <property name="apps">
+            <set>
+                <ref bean="kenyaemr.app.reports" />
+            </set></property>
     </bean>
 </beans>

--- a/omod/src/main/webapp/resources/htmlforms/prep/prepFollowupVisit.html
+++ b/omod/src/main/webapp/resources/htmlforms/prep/prepFollowupVisit.html
@@ -1149,7 +1149,7 @@
                 <tr>
                     <td> <b>Signs and symptoms <br /> of acute HIV</b> </td>
                     <td> <b>Adherence counselling done</b> </td>
-                    <!--<td> <b>Medically ineligible <br />to start PrEP</b> </td>-->
+                    <td> <b>Adherence outcome</b> </td>
                     <td width="250"> <b>Contraindication for PrEP</b> </td>
                     <td> <b>PrEP treatment plan </b> </td>
                     <td> <b>Condoms issued</b> </td>


### PR DESCRIPTION
Added a linelist for prep clients eligible for HTS test, bug fix for prep followup adherence outcome
 => I have also refactored PrEPPopulationTypeDataDefinition  to PrEPHTSPopulationTypeDataDefinition since there are two definitions one sourcing form HTS and another prep enrollmen
![prep_eligible](https://user-images.githubusercontent.com/1901372/152357620-661b6e0c-0e81-48e1-bfc3-19a984be3712.PNG)
t