### PR TITLE
Include Dapivirine Vaginal Ring on PrEP,CAB-LA

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/prep/initialFollowup.html
+++ b/omod/src/main/webapp/resources/htmlforms/prep/initialFollowup.html
@@ -52,6 +52,7 @@
 		var vmmcScreened = "<lookup expression="fn.latestObs(165352).getValueCoded()"/>";
 		var circumsised = "<lookup expression="fn.latestObs(165099).getValueCoded()"/>";
 		var gender = "<lookup expression="patient.gender" />";
+		var pAge = parseInt('<lookup expression="patient.age"/>');
 		var sexWithoutCondom = "<lookup expression="fn.latestObs(165097).getValueCoded()"/>";
 		var sexPartnerHivStatus = "<lookup expression="fn.latestObs(1436).getValueCoded()"/>";
 
@@ -96,7 +97,12 @@
             jq('#fair-bad-reasons').hide();
             jq('#fair-bad-label').hide();
             jq('#reason-fair-other').hide();
-
+            jq('#type-of-prep').hide();
+            jq('#type-of-prep-option').hide();
+            jq('#reason-for-switching').hide();
+            jq('#reason-for-switching-option').hide();
+            jq('#date-of-switching').hide();
+            jq('#date-of-switching-option').hide();
 
 
 			jq('#sti_screened :input[type=radio]').change(onStiScreenedSelected);
@@ -119,8 +125,27 @@
             jq('#adherence-assessment :input[type=radio]').change(adherenceAssessmentSelected);
             jq('#adherence-outcome :input[type=radio]').change(adherenceOutcomeSelected);
             jq('#fair-bad').click(showOptionsOther);
+            jq('#type-of-prep-option :input[type=radio]').click(typeOfPrep);
+            var currentPrepRegimen= "<lookup expression='fn.latestObs(164515).getValueCoded()' />";
+            var currentPrepRegimenReg = currentPrepRegimen.replace(/[^\d]/g, '');
 
+            if(currentPrepRegimenReg == 161364){
+                jq('#current-prep-regimen').html("TDF/3TC");
+            }else if(currentPrepRegimenReg ==84795){
+                jq('#current-prep-regimen').html("TDF");
+            }else if(currentPrepRegimenReg ==104567){
+                jq('#current-prep-regimen').html("TDF/FTC(Preferred)");
+            }else if(currentPrepRegimenReg ==168050){
+                jq('#current-prep-regimen').html("CAB-LA");
+            }else if(currentPrepRegimenReg ==168049){
+                jq('#current-prep-regimen').html("Dapivirine Ring");
+            }else{
+                jq('#current-prep-regimen').html("");
+            }
 
+            if (gender == 'F') {
+				jq("#type-of-prep-option input[value=5424]").prop("disabled", true);
+            }
 
 
 			creatininelabs();
@@ -349,6 +374,24 @@
 
 			}
 		}
+		function typeOfPrep(){
+		var val = jq(this).val();
+		 if((val == 165269)  || (val == 5424)) {
+		  	jq('#regimen-options').show();
+			jq('#regimen').show();
+			jq('#months-options').show();
+			jq('#number-of-months').show();
+		 }else{
+		 	jq('#regimen-options').hide();
+			jq('#regimen').hide();
+			jq('#months-options').hide();
+			jq('#number-of-months').hide();
+			clearHiddenSections(jq('#months-option'));
+			clearHiddenSections(jq('#regimen'));
+
+		 }
+		}
+
 		function isStiScreened() {
 			var val = jq(this).val();
 			if(val ==1066) {
@@ -580,23 +623,45 @@
 				jq("#treatment-plan input[value=1260]").prop("checked", false);
 			}
 		}
-		function prepStatus() {
 
+
+		function prepStatus() {
 			var status = jq(this).val();
 			if(status ==1256 || status ==1257||status ==162904) {
-				jq('#months-options').show();
-				jq('#number-of-months').show();
-				jq('#prescription-option').show();
-				jq('#prescription').show();
-				jq('#regimen-options').show();
-				jq('#regimen').show()
-			}else {
-				jq('#months-options').hide();
 				jq('#number-of-months').hide();
 				jq('#prescription-option').hide();
 				jq('#prescription').hide();
-				jq('#regimen-options').hide();
-				jq('#regimen').hide()
+				jq('#reason-for-switching').hide();
+                jq('#reason-for-switching-option').hide();
+                jq('#date-of-switching').hide();
+                jq('#date-of-switching-option').hide();
+                jq('#type-of-prep').hide();
+                jq('#type-of-prep-option').hide();
+                jq('#months-options').hide();
+                jq('#regimen-options').hide();
+			    jq('#regimen').hide();
+			}else if(status ==164515){
+			    jq('#reason-for-switching').show();
+                jq('#reason-for-switching-option').show();
+                jq('#date-of-switching').show();
+                jq('#date-of-switching-option').show();
+                jq('#type-of-prep').show();
+                jq('#type-of-prep-option').show();
+
+			}else {
+				jq('#number-of-months').hide();
+				jq('#prescription-option').hide();
+				jq('#prescription').hide();
+				jq('#reason-for-switching').hide();
+                jq('#reason-for-switching-option').hide();
+                jq('#date-of-switching').hide();
+                jq('#date-of-switching-option').hide();
+                jq('#type-of-prep').hide();
+                jq('#type-of-prep-option').hide();
+                jq('#months-options').hide();
+                jq('#regimen-options').hide();
+			    jq('#regimen').hide();
+
 			}
 		}
 
@@ -632,6 +697,7 @@
             }
         }
 		clearHiddenSections = function(parentObj) {
+
 			for(var i=0; i &lt; parentObj.length; i++){
 				parentObj[i].find('input[type=radio]').each(function() {
 					this.checked = false;
@@ -646,6 +712,7 @@
 					this.selectedIndex =0;
 				});
 			}
+
 		}
 
 	</script>
@@ -726,7 +793,7 @@
 						</td>
 						<td><obs conceptId="165356" id="months"/>Month(s)</td>
 						<td>
-						<span class="value"><recentObs conceptId="4978edd0-75ab-40a9-9c07-d4bbeb43fed5"/></span>
+							<span class="value"><recentObs conceptId="4978edd0-75ab-40a9-9c07-d4bbeb43fed5"/></span>
 						</td>
 					</tr>
 					<tr>
@@ -760,29 +827,29 @@
 					<td id="sti-signs">
 						<div id="sti-symptoms" style="float: left; padding-right: 50px">
 							<includeIf velocityTest="$patient.gender == 'F' ">
-							<obs conceptId="165098" id="sti-genital"
-								 answerConceptId="145762AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-								 answerLabel="Genital Ulcer Disease(GUD)" style="checkbox" />
+								<obs conceptId="165098" id="sti-genital"
+									 answerConceptId="145762AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+									 answerLabel="Genital Ulcer Disease(GUD)" style="checkbox" />
 
-							<br />
-							<obs conceptId="165098" id="sti-vaginal"
-								 answerConceptId="121809AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-								 answerLabel="Vaginitis and/or Vaginal Discharge(VG)" style="checkbox"/>
-							<br />
-							<obs conceptId="165098" id="sti-cervical"
-								 answerConceptId="116995AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-								 answerLabel="Cervicitis and/or Cervical Discharge(CD)" style="checkbox"/>
-							<br />
-							<obs conceptId="165098" id="sti-pelvic"
-								 answerConceptId="130644AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-								 answerLabel="Pelvic Inflammatory Disease(PID)" style="checkbox"/>
-							<br />
+								<br />
+								<obs conceptId="165098" id="sti-vaginal"
+									 answerConceptId="121809AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+									 answerLabel="Vaginitis and/or Vaginal Discharge(VG)" style="checkbox"/>
+								<br />
+								<obs conceptId="165098" id="sti-cervical"
+									 answerConceptId="116995AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+									 answerLabel="Cervicitis and/or Cervical Discharge(CD)" style="checkbox"/>
+								<br />
+								<obs conceptId="165098" id="sti-pelvic"
+									 answerConceptId="130644AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+									 answerLabel="Pelvic Inflammatory Disease(PID)" style="checkbox"/>
+								<br />
 							</includeIf>
 							<includeIf velocityTest="$patient.gender == 'M' ">
-							<obs conceptId="165098" id="sti-urethral"
-								 answerConceptId="123529AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-								 answerLabel="Urethral Discharge(UD)" style="checkbox"/>
-							<br />
+								<obs conceptId="165098" id="sti-urethral"
+									 answerConceptId="123529AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+									 answerLabel="Urethral Discharge(UD)" style="checkbox"/>
+								<br />
 							</includeIf>
 							<obs conceptId="165098" id="sti-anal"
 								 answerConceptId="148895AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -1207,9 +1274,7 @@
 					<td> <b>Adherence outcome</b> </td>
 					<td width="250" id="fair-bad-label">If fair or poor, what are the reasons?	</td>
 					<td width="250"> <b>Contraindication for PrEP</b> </td>
-					<td> <b>PrEP treatment plan </b> </td>
-					<td> <b>Condoms issued</b> </td>
-					<td id="condom-issiued-label"> <b>Number of condoms issued</b> </td>
+
 				</tr>
 				<tr>
 					<td>
@@ -1249,34 +1314,65 @@
 						<obs conceptId="165106" answerConceptId="127750AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" answerLabel="Not willing" style="checkbox"/> <br />
 						<obs conceptId="165106" answerConceptId="165105" answerLabel="Less than 35ks and under 15 yrs" style="checkbox"/> <br />
 					</td>
+
+				</tr>
+			</table>
+		</fieldset>
+		<fieldset>
+			<legend>PrEP Treatment Plan</legend>
+			<table class="simple-table">
+				<tr>
+					<td> <b>Current PrEP Regimen </b> </td>
+					<td> <b>PrEP treatment plan </b> </td>
+					<td id="reason-for-switching"> <b>Reason for Switching? </b> </td>
+					<td id="date-of-switching"> <b>Date of Switch </b> </td>
+					<td id="prescription"> <b>Prescribed PrEP today? </b> </td>
+					<td id="type-of-prep"> <b>Type of PrEP </b> </td>
+					<td id="regimen"> <b>Regimen prescribed </b> </td>
+					<td id="number-of-months"><b>Number of months</b></td>
+					<td> <b>Condoms issued</b> </td>
+					<td id="condom-issiued-label"> <b>Number of condoms issued</b> </td>
+				</tr>
+				<tr>
 					<td>
-						<table>
-							<tr>
-
-								<td>
-									<!-- PrEP TREATMENT PLAN -->
-									<obs conceptId="165109" id="treatment-plan"
-										 answerConceptIds="1256AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1257AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,162904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1260AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-										 answerLabels="Start,Continue,Restart,Discontinue"   answerSeparator="&lt;br /&gt;"
-										 style="radio" required="true" />
-								</td>
-
-								<td id="prescription">Prescribed PrEP today?</td>
-								<td id="prescription-option"><obs conceptId="1417" labelText=" " answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
-										1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" style="radio" answerLabels="Yes,No" />
-								</td>
-
-								<td id="regimen">Regimen prescribed</td>
-								<td id="regimen-options"><obs conceptId="164515" labelText=" " answerConceptIds="161364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
-										84795AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,104567AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-															  answerLabels="TDF/3TC,TDF,TDF/FTC(Preferred)" />
-								</td>
-								<td id="number-of-months">Number of months</td>
-								<td id="months-options"><obs conceptId="164433AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" id="regimen-months-prescribed"/></td>
-
-							</tr>
-						</table>
+						<span id="current-prep-regimen"></span>
 					</td>
+					<td><obs id="treatment-plan"
+							 conceptId="167788"
+							 style="radio"
+							 answerConceptIds="1256AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1257AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,162904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,164515,1260AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+							 answerLabels="Start,Continue,Restart,Switch,Discontinue"
+							 answerSeparator="&lt;br /&gt;"/>
+					</td>
+
+					<td id="reason-for-switching-option"><obs
+							conceptId="167788"
+							answerConceptIds="159737,160662,121760,141748,167533"
+							answerLabels="Client Preference,Stock-out,Adverse Drug Reactions,Drug Interactions,Discontinuing Inj. PrEP"
+							answerSeparator="&lt;br /&gt;"/>
+					</td>
+					<td id="date-of-switching-option">
+						<obs conceptId="165144"/>
+					</td>
+					<td width="100" id="prescription-option">
+						<obs conceptId="1417"
+							 answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+							 answerLabel="Yes,No"
+							 style="radio"/>
+					</td>
+					<td id="type-of-prep-option">
+						<obs
+								conceptId="165109"
+								style="radio"
+								answerConceptIds="165269,168050,168049, 5424"
+								answerLabels="Daily Oral PrEP,CAB-LA,Dapivirine ring,Event Driven"
+								answerSeparator="&lt;br /&gt;"/>
+					</td>
+					<td id="regimen-options"><obs conceptId="164515" labelText=" " answerConceptIds="161364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+										84795AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,104567AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,168050,168049"
+												  answerLabels="TDF/3TC,TDF,TDF/FTC(Preferred),CAB-LA,Dapivirine Ring" />
+					</td>
+					<td id="months-options"><obs conceptId="164433AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/></td>
 					<td width="100">
 						<obs conceptId="159777" id="condom-issued"
 							 answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"


### PR DESCRIPTION
Dapivirine Vaginal Ring is the recommended non-oral PrEP and needs to be added in the EMR to allow data capture and reporting

Dapivirine ring, 25mg, inserted vaginally and used for 28 days continuously without removal.

To do

    Add the Dapivirine Vaginal ring on PrEP forms (Initial, Follow up and Monthly refill forms) as a type of PrEP.

    Hide the regimen prescribed and number of months if user selects Dapivirine ring.
Dapivirine Vaginal Ring is the recommended non-oral PrEP and needs to be added in the EMR to allow data capture and reporting

Dapivirine ring, 25mg, inserted vaginally and used for 28 days continuously without removal.

To do

    Add the Dapivirine Vaginal ring on PrEP forms (Initial, Follow up and Monthly refill forms) as a type of PrEP.

    Hide the regimen prescribed and number of months if user selects Dapivirine ring.